### PR TITLE
Add mocked event store

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Save events, publish it and recreate an aggregate from `event store` is made by 
 
 ## Event Store
 
-Currently it has support for `MongoDB`, `Rethinkdb` is in the scope to be add
+Currently it has support for `MongoDB` and a [mock implementation for development](#mocked-event-store). `Rethinkdb` is in the scope to be added.
 
 ```go
 import "github.com/mishudark/eventhus/config"
@@ -137,10 +137,9 @@ config.Mongo("localhost", 27017, "bank") // event store
 ```
 we create an eventstore with `config.Mongo`, it accepts `host`, `port` and `table` as arguments
 
-
 ## Event Publisher
 
-`RabbitMQ` and `Nats.io` are supported
+`RabbitMQ` and `Nats.io` are supported and a [mock implementation for development](#mocked-event-bus) is there too. 
 
 ```go
 import 	"github.com/mishudark/eventhus/config"
@@ -219,6 +218,25 @@ You should listen your `eventbus`, the format of the event allways is the same, 
 	}
 }
 ```
+
+## Mock Classes
+
+There are mock implementations for development without an actual event store or event bus.
+
+### Mocked Event Store
+
+```go
+import "github.com/mishudark/eventhus/config"
+...
+
+config.MockEventStore()
+```
+
+This requires no configuration and stores the events internally in a map, mapping the aggregate ids to an array of events.
+
+### Mocked Event Bus
+
+*Currently not implemented. This is quiet easy, you should give it a try ; )*
 
 ## Prior Art
 

--- a/README.md
+++ b/README.md
@@ -223,6 +223,8 @@ You should listen your `eventbus`, the format of the event allways is the same, 
 
 There are mock implementations for development without an actual event store or event bus.
 
+For Details, have a look inside the `mock` packages (example: `eventhus/eventbus/mock`)
+
 ### Mocked Event Store
 
 ```go
@@ -236,7 +238,14 @@ This requires no configuration and stores the events internally in a map, mappin
 
 ### Mocked Event Bus
 
-*Currently not implemented. This is quiet easy, you should give it a try ; )*
+```go
+import "github.com/mishudark/eventhus/config"
+...
+
+config.MockEventBus()
+```
+
+This implementation simply does nothing with the events.
 
 ## Prior Art
 

--- a/config/config.go
+++ b/config/config.go
@@ -3,11 +3,12 @@ package config
 import (
 	"github.com/mishudark/eventhus"
 	"github.com/mishudark/eventhus/commandbus/async"
+	mockBus "github.com/mishudark/eventhus/eventbus/mock"
 	"github.com/mishudark/eventhus/eventbus/mosquitto"
 	"github.com/mishudark/eventhus/eventbus/nats"
 	"github.com/mishudark/eventhus/eventbus/rabbitmq"
 	"github.com/mishudark/eventhus/eventstore/badger"
-	"github.com/mishudark/eventhus/eventstore/mock"
+	mockStore "github.com/mishudark/eventhus/eventstore/mock"
 	"github.com/mishudark/eventhus/eventstore/mongo"
 )
 
@@ -78,6 +79,13 @@ func Mosquitto(method string, host string, port int, clientID string) EventBus {
 	}
 }
 
+// Generates a mocked event bus that should only be used during development.
+func MockEventBus() EventBus {
+	return func() (eventhus.EventBus, error) {
+		return mockBus.NewClient(), nil
+	}
+}
+
 // Mongo generates a MongoDB implementation of EventStore
 func Mongo(host string, port int, db string) EventStore {
 	return func() (eventhus.EventStore, error) {
@@ -95,7 +103,7 @@ func Badger(dbDir string) EventStore {
 // Generates a mocked, in-memory event store that should only be used during development
 func MockEventStore() EventStore {
 	return func() (eventhus.EventStore, error) {
-		return mock.NewClient(), nil
+		return mockStore.NewClient(), nil
 	}
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -7,6 +7,7 @@ import (
 	"github.com/mishudark/eventhus/eventbus/nats"
 	"github.com/mishudark/eventhus/eventbus/rabbitmq"
 	"github.com/mishudark/eventhus/eventstore/badger"
+	"github.com/mishudark/eventhus/eventstore/mock"
 	"github.com/mishudark/eventhus/eventstore/mongo"
 )
 
@@ -88,6 +89,13 @@ func Mongo(host string, port int, db string) EventStore {
 func Badger(dbDir string) EventStore {
 	return func() (eventhus.EventStore, error) {
 		return badger.NewClient(dbDir)
+	}
+}
+
+// Generates a mocked, in-memory event store that should only be used during development
+func MockEventStore() EventStore {
+	return func() (eventhus.EventStore, error) {
+		return mock.NewClient(), nil
 	}
 }
 

--- a/eventbus/mock/mock.go
+++ b/eventbus/mock/mock.go
@@ -1,0 +1,26 @@
+package mock
+
+import (
+	"github.com/mishudark/eventhus"
+)
+
+type Client struct{}
+
+/*
+Creates a new mocked event bus.
+
+This does implementation is rather crude and does not perfectly mimic the behaviour of
+the other implementations.
+
+Warning: All events published by this client are simply thrown away and not used in any way!
+
+Therefore this should only be used to try out eventhus without
+having to connect to an event store or an event bus.
+*/
+func NewClient() *Client {
+	return &Client{}
+}
+
+func (c *Client) Publish(event eventhus.Event, bucket, subset string) error {
+	return nil
+}

--- a/eventstore/mock/mock.go
+++ b/eventstore/mock/mock.go
@@ -15,7 +15,7 @@ Creates a new mocked event store.
 This does implementation is rather crude and does not perfectly mimic the behaviour of
 the other implementations.
 
-Therefore this mocked store should only be used to try out eventhus without
+Therefore this should only be used to try out eventhus without
 having to connect to an event store or an event bus.
 */
 func NewClient() *Client {

--- a/eventstore/mock/mock.go
+++ b/eventstore/mock/mock.go
@@ -9,6 +9,15 @@ type Client struct {
 	events map[string][]eventhus.Event
 }
 
+/*
+Creates a new mocked event store.
+
+This does implementation is rather crude and does not perfectly mimic the behaviour of
+the other implementations.
+
+Therefore this mocked store should only be used to try out eventhus without
+having to connect to an event store or an event bus.
+*/
 func NewClient() *Client {
 	return &Client{
 		events: make(map[string][]eventhus.Event),

--- a/eventstore/mock/mock.go
+++ b/eventstore/mock/mock.go
@@ -34,7 +34,12 @@ func (c *Client) Save(events []eventhus.Event, version int) error {
 }
 
 func (c *Client) SafeSave(events []eventhus.Event, version int) error {
-	panic("SafeSave is not yet implemented on the mocked event store!")
+	for _, event := range events {
+		aggregateId := event.AggregateID
+		c.events[aggregateId] = append(c.events[aggregateId], event)
+	}
+
+	return nil
 }
 
 func (c *Client) Load(aggregateID string) ([]eventhus.Event, error) {

--- a/eventstore/mock/mock.go
+++ b/eventstore/mock/mock.go
@@ -1,0 +1,33 @@
+package mock
+
+import (
+	"github.com/mishudark/eventhus"
+)
+
+type Client struct {
+	// Maps aggregate ids to their event arrays
+	events map[string][]eventhus.Event
+}
+
+func NewClient() *Client {
+	return &Client{
+		events: make(map[string][]eventhus.Event),
+	}
+}
+
+func (c *Client) Save(events []eventhus.Event, version int) error {
+	for _, event := range events {
+		aggregateId := event.AggregateID
+		c.events[aggregateId] = append(c.events[aggregateId], event)
+	}
+
+	return nil
+}
+
+func (c *Client) SafeSave(events []eventhus.Event, version int) error {
+	panic("SafeSave is not yet implemented on the mocked event store!")
+}
+
+func (c *Client) Load(aggregateID string) ([]eventhus.Event, error) {
+	return c.events[aggregateID], nil
+}

--- a/eventstore/mock/mock_test.go
+++ b/eventstore/mock/mock_test.go
@@ -1,0 +1,79 @@
+package mock
+
+import (
+	"github.com/mishudark/eventhus"
+	"github.com/oklog/ulid"
+	"math/rand"
+	"testing"
+	"time"
+)
+
+type SubEvent2 struct {
+	Name string
+	SKU  string
+}
+
+func TestClient_LoadEmptyShouldReturn0Events(t *testing.T) {
+	store := NewClient()
+	events, err := store.Load("new-aggregate")
+
+	if err != nil {
+		t.Error("Unexpected error", err)
+	}
+
+	if events != nil {
+		t.Error("Function returned nil!")
+	}
+
+	if l := len(events); l != 0 {
+		t.Error("Expected 0 events, returned were", l)
+	}
+}
+
+func TestClient_SaveAndLoad(t *testing.T) {
+	store := NewClient()
+
+	ta := time.Now()
+	entropy := rand.New(rand.NewSource(ta.UnixNano()))
+	aid := ulid.MustNew(ulid.Timestamp(ta), entropy)
+
+	aggregateId := aid.String()
+	events := []eventhus.Event{
+		{
+			AggregateID:   aggregateId,
+			AggregateType: "order",
+			Version:       1,
+			Type:          "SubEvent2",
+			Data: SubEvent2{
+				Name: "muñeca",
+				SKU:  "123",
+			},
+		},
+		{
+			AggregateID:   aggregateId,
+			AggregateType: "order",
+			Version:       1,
+			Type:          "SubEvent2",
+			Data: SubEvent2{
+				Name: "muñeca",
+				SKU:  "123",
+			},
+		},
+	}
+
+	err := store.Save(events, 0)
+
+	if err != nil {
+		t.Error("Unexpected error", err)
+	}
+
+	events, err = store.Load(aggregateId)
+
+	if err != nil {
+		t.Error("Unexpected error", err)
+	}
+
+	if l := len(events); l != 2 {
+		t.Error("Expected 2 events, returned were", l)
+	}
+}


### PR DESCRIPTION
This PR adds a mocked event store.

## Background

For testing I'd like to use this library without an actual mongodb and rabbitmq.

For that I need mock implementations (or in-memory) which I try to create right now.

## Changes

- Add package `eventstore/mock` including basic tests
- Update documentation (which includes texts for a mocked event bus which I'd like to add later)